### PR TITLE
set default execution order to DebugSheet.

### DIFF
--- a/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugSheet.cs
+++ b/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugSheet.cs
@@ -10,6 +10,7 @@ using UnityEngine.UI;
 
 namespace UnityDebugSheet.Runtime.Core.Scripts
 {
+    [DefaultExecutionOrder(int.MinValue)]
     public sealed class DebugSheet : MonoBehaviour, IPageContainerCallbackReceiver
     {
         private const float ThresholdInch = 0.24f;


### PR DESCRIPTION
* Set DefaultExecutionOrder of DebugSheet to allow singleton access at any time.

-----

* シングルトンにいつでもアクセス可能にするため、DebugSheetのDefaultExecutionOrderを設定しました