### PR TITLE
fix null err on Loading UnityDebugSheet prefab from Addressable.

### DIFF
--- a/Assets/UnityDebugSheet/Runtime/Foundation/Drawer/CanvasGroupDrawerBackdrop.cs
+++ b/Assets/UnityDebugSheet/Runtime/Foundation/Drawer/CanvasGroupDrawerBackdrop.cs
@@ -7,12 +7,16 @@ namespace UnityDebugSheet.Runtime.Foundation.Drawer
     {
         private CanvasGroup _canvasGroup;
         
+        private void Awake()
+        {
+            _canvasGroup = GetComponent<CanvasGroup>();
+        }
+
         protected override void OnStart()
         {
             base.OnStart();
-            _canvasGroup = GetComponent<CanvasGroup>();
         }
-        
+
         protected override void SetProgressInternal(float visibility)
         {
             _canvasGroup.alpha = visibility;


### PR DESCRIPTION
There will cause err when loading "DebugSheetCanvas" prefab form Addressable or any other asset-Bundle based AssetManagement way.

It will call SetProgressInternal before OnStart