### PR TITLE
fix: prevent text loss in UITextEllipsisOverflow

### DIFF
--- a/Assets/UnityDebugSheet/Runtime/Foundation/UITextEllipsisOverflow.cs
+++ b/Assets/UnityDebugSheet/Runtime/Foundation/UITextEllipsisOverflow.cs
@@ -15,7 +15,8 @@ namespace UnityDebugSheet.Runtime.Foundation
         [SerializeField] [Tooltip("If set to true, the text will actually be overwritten in EditMode.")]
         private bool _applyInEditMode = true;
 
-        private string _textValue;
+        private string _textValue = string.Empty;
+        private string _originalTextValue = string.Empty;
 
         protected override void Awake()
         {
@@ -24,6 +25,7 @@ namespace UnityDebugSheet.Runtime.Foundation
             {
                 _text = GetComponent<Text>();
                 _textValue = _text.text;
+                _originalTextValue = _text.text;
             }
         }
 
@@ -32,8 +34,9 @@ namespace UnityDebugSheet.Runtime.Foundation
             if (_text.text == _textValue) 
                 return;
             
-            _textValue = _text.text;
+            _originalTextValue = _text.text;
             Apply();
+            _textValue = _text.text;
         }
 
         protected override void OnRectTransformDimensionsChange()
@@ -57,12 +60,12 @@ namespace UnityDebugSheet.Runtime.Foundation
 
             if (!IsActive() || _text == null) return;
 
+            var text = _originalTextValue;
+
             var rectTransform = _text.rectTransform;
             var generator = _text.cachedTextGenerator;
             var settings = _text.GetGenerationSettings(rectTransform.rect.size);
-            generator.Populate(_text.text, settings);
-
-            var text = _text.text;
+            generator.Populate(text, settings);
 
             if (rectTransform.rect.width <= 0 || rectTransform.rect.height <= 0)
                 // Do nothing because the layout seems not to have been built yet.


### PR DESCRIPTION
### Dear Maintainer,

I am submitting this PR to address a bug where the UITextEllipsisOverflow component permanently clears the text when it is initialized within dynamic layout systems (such as GridLayoutGroup).


### Summary of Changes

<img width="1472" height="770" alt="Unity_gSdidbN1AP" src="https://github.com/user-attachments/assets/0daad1a0-d36e-4feb-9d1a-65d0e27d0813" />

> Before Fix: There was an issue where labels were cleared if the number of buttons added to a ButtonCollection was 2 or fewer.

<img width="1472" height="770" alt="Unity_c8JgK6BwdC" src="https://github.com/user-attachments/assets/414c61a5-2204-40aa-9252-1284f00657e4" />

> After Fix: Labels are preserved and displayed correctly regardless of the button count.


### How to Reproduce
In [DefaultCellDemoDebugPage.cs](https://github.com/Haruma-K/UnityDebugSheet/blob/2b1cf90f0375e10c9c0909cc91c5b92d707f2ce3/Assets/Demo/02_DefaultCells/Scripts/DefaultCellsDemoDebugPage.cs#L210), simply change line 210 from for (var i = 0; i < 9; i++) to for (var i = 0; i < 2; i++).


### The Problem
The issue stems from a timing conflict between text assignment and layout initialization:
1. Assignment: New text is assigned to the component (e.g., during a cell's Setup).
2. Premature Truncation: The component immediately runs its Apply() logic using the initial dimensions of the RectTransform.
3. Data Loss: If these initial dimensions have not yet been properly calculated by the layout engine, the component determines that there is insufficient space and begins removing characters from the text one by one from the end, eventually removing them all.
4. Layout Initialization: When the layout is subsequently initialized and the dimensions are updated, the original text is already lost, leaving the UI element empty.


### The Solution
I have updated the component to decouple the Original Text (Source of Truth) from the Display Output:
- The component now preserves the original string whenever a new value is assigned.
- It always uses this preserved original text as the starting point for truncation.
- This allows the component to correctly re-calculate the ellipsis during OnRectTransformDimensionsChange once the layout initialization is complete.

This change ensures that text remains visible and correctly truncated regardless of whether the ellipsis logic triggers before or after the layout engine provides the final dimensions.