### PR TITLE
Fix obsolete GetInstanceID error on Unity 6000.5+

### DIFF
--- a/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugPageBase.cs
+++ b/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugPageBase.cs
@@ -4,6 +4,11 @@ using UnityDebugSheet.Runtime.Foundation.PageNavigator;
 using UnityDebugSheet.Runtime.Foundation.PageNavigator.Modules;
 using UnityDebugSheet.Runtime.Foundation.TinyRecyclerView;
 using UnityEngine;
+#if UNITY_6000_5_OR_NEWER
+using ObjectId = UnityEngine.EntityId;
+#else
+using ObjectId = System.Int32;
+#endif
 
 namespace UnityDebugSheet.Runtime.Core.Scripts
 {
@@ -12,7 +17,7 @@ namespace UnityDebugSheet.Runtime.Core.Scripts
         private readonly PriorityList<int> _itemIds = new PriorityList<int>();
         private readonly Dictionary<int, int> _itemIdToDataIndexMap = new Dictionary<int, int>();
         private readonly List<ItemInfo> _itemInfos = new List<ItemInfo>();
-        private readonly Dictionary<int, string> _objIdToPrefabKeyMap = new Dictionary<int, string>();
+        private readonly Dictionary<ObjectId, string> _objIdToPrefabKeyMap = new Dictionary<ObjectId, string>();
 
         private readonly Dictionary<string, ObjectPool<GameObject>> _prefabPools =
             new Dictionary<string, ObjectPool<GameObject>>();
@@ -73,6 +78,15 @@ namespace UnityDebugSheet.Runtime.Core.Scripts
                 pool.Clear();
         }
 
+        private static ObjectId GetObjectId(Object obj)
+        {
+#if UNITY_6000_5_OR_NEWER
+            return obj.GetEntityId();
+#else
+            return obj.GetInstanceID();
+#endif
+        }
+
         GameObject IRecyclerViewCellProvider.GetCell(int dataIndex)
         {
             var prefabKey = _itemInfos[dataIndex].PrefabKey;
@@ -87,14 +101,14 @@ namespace UnityDebugSheet.Runtime.Core.Scripts
             }
 
             var obj = pool.Use();
-            _objIdToPrefabKeyMap[obj.GetInstanceID()] = prefabKey;
+            _objIdToPrefabKeyMap[GetObjectId(obj)] = prefabKey;
             obj.SetActive(true);
             return obj;
         }
 
         void IRecyclerViewCellProvider.ReleaseCell(GameObject obj)
         {
-            var prefabKey = _objIdToPrefabKeyMap[obj.GetInstanceID()];
+            var prefabKey = _objIdToPrefabKeyMap[GetObjectId(obj)];
             var pool = _prefabPools[prefabKey];
             pool.Release(obj);
             obj.SetActive(false);

--- a/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugSheet.cs
+++ b/Assets/UnityDebugSheet/Runtime/Core/Scripts/DebugSheet.cs
@@ -9,6 +9,11 @@ using UnityDebugSheet.Runtime.Foundation.PageNavigator.Modules.AssetLoader;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
+#if UNITY_6000_5_OR_NEWER
+using ObjectId = UnityEngine.EntityId;
+#else
+using ObjectId = System.Int32;
+#endif
 
 namespace UnityDebugSheet.Runtime.Core.Scripts
 {
@@ -17,8 +22,8 @@ namespace UnityDebugSheet.Runtime.Core.Scripts
     {
         private const float ThresholdInch = 0.24f;
 
-        private static readonly Dictionary<int, DebugSheet> InstanceCacheByTransform =
-            new Dictionary<int, DebugSheet>();
+        private static readonly Dictionary<ObjectId, DebugSheet> InstanceCacheByTransform =
+            new Dictionary<ObjectId, DebugSheet>();
 
         [SerializeField] private bool _singleton = true;
 
@@ -197,7 +202,11 @@ namespace UnityDebugSheet.Runtime.Core.Scripts
         /// <returns></returns>
         public static DebugSheet Of(RectTransform rectTransform, bool useCache = true)
         {
+#if UNITY_6000_5_OR_NEWER
+            var id = rectTransform.GetEntityId();
+#else
             var id = rectTransform.GetInstanceID();
+#endif
 
             if (useCache && InstanceCacheByTransform.TryGetValue(id, out var container)) return container;
 

--- a/Assets/UnityDebugSheet/Runtime/Foundation/PageNavigator/PageContainer.cs
+++ b/Assets/UnityDebugSheet/Runtime/Foundation/PageNavigator/PageContainer.cs
@@ -104,7 +104,7 @@ namespace UnityDebugSheet.Runtime.Foundation.PageNavigator
             _orderedPageIds.Clear();
 
             InstanceCacheByName.Remove(_name);
-            var keysToRemove = new List<int>();
+            var keysToRemove = new List<ObjectId>();
             foreach (var cache in InstanceCacheByTransform)
                 if (Equals(cache.Value))
                     keysToRemove.Add(cache.Key);

--- a/Assets/UnityDebugSheet/Runtime/Foundation/PageNavigator/PageContainer.cs
+++ b/Assets/UnityDebugSheet/Runtime/Foundation/PageNavigator/PageContainer.cs
@@ -6,6 +6,11 @@ using UnityDebugSheet.Runtime.Foundation.PageNavigator.Modules.AssetLoader;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.UI;
+#if UNITY_6000_5_OR_NEWER
+using ObjectId = UnityEngine.EntityId;
+#else
+using ObjectId = System.Int32;
+#endif
 
 namespace UnityDebugSheet.Runtime.Foundation.PageNavigator
 {
@@ -13,8 +18,8 @@ namespace UnityDebugSheet.Runtime.Foundation.PageNavigator
     [RequireComponent(typeof(RectMask2D))]
     public sealed class PageContainer : MonoBehaviour
     {
-        private static readonly Dictionary<int, PageContainer> InstanceCacheByTransform =
-            new Dictionary<int, PageContainer>();
+        private static readonly Dictionary<ObjectId, PageContainer> InstanceCacheByTransform =
+            new Dictionary<ObjectId, PageContainer>();
 
         private static readonly Dictionary<string, PageContainer> InstanceCacheByName =
             new Dictionary<string, PageContainer>();
@@ -127,7 +132,11 @@ namespace UnityDebugSheet.Runtime.Foundation.PageNavigator
         /// <returns></returns>
         public static PageContainer Of(RectTransform rectTransform, bool useCache = true)
         {
+#if UNITY_6000_5_OR_NEWER
+            var id = rectTransform.GetEntityId();
+#else
             var id = rectTransform.GetInstanceID();
+#endif
             if (useCache && InstanceCacheByTransform.TryGetValue(id, out var container))
                 return container;
 


### PR DESCRIPTION
Unity 6000.5 turns `Object.GetInstanceID()` into a compile error (CS0619) in favor of `GetEntityId()`. `DebugPageBase` now uses `GetEntityId()` on 6000.5+ and keeps `GetInstanceID()` on older versions via a version guard, so the package compiles on both.